### PR TITLE
Revert "Fixed issue with cursor returning null."

### DIFF
--- a/src/MongoQB/Builder.php
+++ b/src/MongoQB/Builder.php
@@ -764,14 +764,15 @@ class Builder
 
         $documents = array();
 
-        try {
-            while ($next = $cursor->next()) {
-                $documents[] = $next;
+        while ($cursor->hasNext()) {
+            try {
+                $documents[] = $cursor->getNext();
             }
-        } catch (\MongoCursorException $Exception) {
             // @codeCoverageIgnoreStart
-            throw new \MongoQB\Exception($Exception->getMessage());
-            // @codeCoverageIgnoreEnd
+            catch (\MongoCursorException $Exception) {
+                throw new \MongoQB\Exception($Exception->getMessage());
+                // @codeCoverageIgnoreEnd
+            }
         }
 
         return $documents;


### PR DESCRIPTION
1.6.0 is really buggy. This issue has since been fixed in: https://github.com/mongodb/mongo-php-driver/commit/04858383e37e66005d684bcc6fb5d4c576fe12dd
